### PR TITLE
support teletype newlines

### DIFF
--- a/index.lua
+++ b/index.lua
@@ -94,6 +94,8 @@ do
 	local stringStartWithoutQuotes = "^[ \t\n]*" --4
 
 	function module.parse(str,config)
+		str = str:gsub("\r\n", "\n")
+
 		local keyName
 		local keyToggle = false
 		local global = {}


### PR DESCRIPTION
meh, windows..
parser is sensitive to this and does not accept CRLF, so just replace `CRLF > LF`.